### PR TITLE
Fix import references and unused imports

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -6,9 +6,8 @@ Prepara o ambiente, valida dependências e configura credenciais.
 import os
 import sys
 import subprocess
-import json
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict
 
 class BugFinderSetup:
     """Classe para configuração inicial do Bug Finder"""
@@ -250,14 +249,15 @@ class BugFinderSetup:
             
             # Testa importação de configurações
             from src.config import get_settings
+            _ = get_settings  # valida import
             print("   ✅ Importação de configurações")
             
             # Testa importação de modelos
-            from src.models import LogEntry, LogLevel
+            from src.models import LogModel, LogLevel
             print("   ✅ Importação de modelos")
             
             # Testa criação de log de exemplo
-            log = LogEntry(
+            _ = LogModel(
                 message="Teste de configuração",
                 level=LogLevel.INFO,
                 timestamp="2024-06-07T12:00:00Z"

--- a/tests/integration/test_tools_integration.py
+++ b/tests/integration/test_tools_integration.py
@@ -1,9 +1,8 @@
 import pytest
-import os
 from unittest.mock import Mock, patch
 from src.tools.github_tool import GitHubTool, GitHubConfig
 from src.tools.discord_tool import DiscordTool, DiscordConfig
-from src.models.issue_model import Issue
+from src.models.issue_model import IssueModel
 
 class TestGitHubToolIntegration:
     """Testes de integração para a ferramenta GitHub"""
@@ -24,7 +23,7 @@ class TestGitHubToolIntegration:
     @pytest.fixture
     def sample_issue(self):
         """Issue de exemplo para testes"""
-        return Issue(
+        return IssueModel(
             title="Bug de Teste",
             description="Descrição do bug de teste",
             labels=["bug", "high-priority"],
@@ -195,7 +194,7 @@ class TestToolsInteraction:
         mock_discord.return_value = mock_discord_response
         
         # Criar issue
-        sample_issue = Issue(
+        sample_issue = IssueModel(
             title="Bug Completo",
             description="Teste de fluxo completo",
             labels=["bug"]


### PR DESCRIPTION
## Summary
- fix import paths and types for GitHub/Discord classes
- update setup script to use `LogModel`
- adjust integration tests to use `IssueModel`

## Testing
- `ruff check scripts/setup.py src/agents/issue_creator_agent.py src/agents/issue_notificator_agent.py tests/integration/test_tools_integration.py`
- `pytest -q` *(fails: ModuleNotFoundError for `dotenv` and `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_6844816c3d9c832982ebd51e54085e73