### PR TITLE
Fix IssueDrafter label conversion

### DIFF
--- a/src/agents/issue_drafter_agent.py
+++ b/src/agents/issue_drafter_agent.py
@@ -336,14 +336,8 @@ This issue was automatically detected and requires investigation.
         except KeyError:
             priority = IssuePriority.MEDIUM
         
-        # Converte labels para enums
-        labels = []
-        for label_str in content.get('labels', []):
-            try:
-                labels.append(IssueLabel[label_str.upper().replace('-', '_')])
-            except KeyError:
-                # Para labels customizadas, adiciona como string
-                labels.append(label_str)
+        # Labels são mantidos como strings
+        labels = list(content.get('labels', []))
         
         return IssueModel(
             title=content['title'],


### PR DESCRIPTION
## Summary
- fix label handling in `IssueDrafterAgent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6844b2eb91a48329a74f5d1efc36dfa8