### PR TITLE
Improve Discord notifications and issue details

### DIFF
--- a/src/agents/bug_finder_system.py
+++ b/src/agents/bug_finder_system.py
@@ -339,6 +339,11 @@ class BugFinderSystem:
                 stack_trace=log_content if len(log_content) < 2000 else log_content[:2000] + "...",
                 additional_context="Automatically detected critical failure requiring immediate attention",
                 suggested_fixes=["Investigate root cause", "Apply emergency fixes", "Monitor system"],
+                resolution_steps=[
+                    "Check system logs for detailed error information",
+                    "Restart affected services to restore functionality",
+                    "Investigate root cause and deploy a fix"
+                ],
                 priority=IssuePriority.URGENT,
                 labels=["critical", "auto-generated", "high-priority", "runtime-error"]
             )

--- a/src/agents/issue_manager_agent.py
+++ b/src/agents/issue_manager_agent.py
@@ -126,7 +126,8 @@ class IssueManagerAgent:
                 error_details=result.get("error_details", {}),
                 stack_trace=result.get("stack_trace"),
                 additional_context=result.get("additional_context"),
-                suggested_fixes=result.get("suggested_fixes", [])
+                suggested_fixes=result.get("suggested_fixes", []),
+                resolution_steps=result.get("resolution_steps", [])
             )
             
             # Configurar prioridade e labels baseado na análise
@@ -274,6 +275,7 @@ class IssueManagerAgent:
                 "stack_trace": issue.draft.stack_trace,
                 "additional_context": issue.draft.additional_context,
                 "suggested_fixes": issue.draft.suggested_fixes,
+                "resolution_steps": issue.draft.resolution_steps,
                 "priority": issue.draft.priority,
                 "labels": [label.value for label in issue.draft.labels]
             }
@@ -321,6 +323,7 @@ class IssueManagerAgent:
             issue.draft.stack_trace = result.get("stack_trace", issue.draft.stack_trace)
             issue.draft.additional_context = result.get("additional_context", issue.draft.additional_context)
             issue.draft.suggested_fixes = result.get("suggested_fixes", issue.draft.suggested_fixes)
+            issue.draft.resolution_steps = result.get("resolution_steps", issue.draft.resolution_steps)
             
             # Atualizar prioridade se especificada
             if "priority" in result:

--- a/src/config/prompts.py
+++ b/src/config/prompts.py
@@ -106,6 +106,9 @@ Crie uma issue completa e profissional que inclua:
 - Urgência da correção
 - Possíveis soluções
 
+### 7. Plano de Correção
+- Passos detalhados para resolver o problema
+
 ## Responda em JSON:
 ```json
 {{
@@ -127,6 +130,7 @@ Crie uma issue completa e profissional que inclua:
     "stack_trace": "stack trace se relevante",
     "additional_context": "contexto adicional importante",
     "suggested_fixes": ["possível solução 1", "possível solução 2"],
+    "resolution_steps": ["passo de resolução 1", "passo 2"],
     "priority": "low|medium|high|urgent",
     "labels": ["label1", "label2", "label3"]
 }}
@@ -227,6 +231,7 @@ Refine a issue original incorporando todo o feedback e seguindo as instruções 
 - Melhorar passos de reprodução
 - Ajustar severidade/prioridade se necessário
 - Adicionar contexto relevante
+- Detalhar plano de correção passo a passo
 
 ## Responda em JSON:
 ```json
@@ -245,6 +250,7 @@ Refine a issue original incorporando todo o feedback e seguindo as instruções 
     "stack_trace": "stack trace se relevante",
     "additional_context": "contexto adicional aprimorado",
     "suggested_fixes": ["solução refinada 1", "solução 2"],
+    "resolution_steps": ["passo de resolução refinado 1", "passo 2"],
     "priority": "prioridade ajustada se necessário",
     "labels": ["labels atualizadas"],
     "refinement_notes": "explicação das mudanças feitas"

--- a/src/models/issue_model.py
+++ b/src/models/issue_model.py
@@ -57,6 +57,7 @@ class IssueDraft(BaseModel):
     related_logs: List[str] = Field(default_factory=list, description="IDs dos logs relacionados")
     additional_context: Optional[str] = Field(None, description="Contexto adicional")
     suggested_fixes: List[str] = Field(default_factory=list, description="Possíveis soluções sugeridas")
+    resolution_steps: List[str] = Field(default_factory=list, description="Passos detalhados para resolver o problema")
     
     def add_label(self, label: IssueLabel) -> None:
         if label not in self.labels:
@@ -133,6 +134,13 @@ class IssueDraft(BaseModel):
             content.append("## Possíveis Soluções")
             for i, fix in enumerate(self.suggested_fixes, 1):
                 content.append(f"{i}. {fix}")
+            content.append("")
+
+        # Plano de resolução detalhado
+        if self.resolution_steps:
+            content.append("## Plano de Resolução")
+            for i, step in enumerate(self.resolution_steps, 1):
+                content.append(f"{i}. {step}")
             content.append("")
         
         # Metadados

--- a/src/models/notification_model.py
+++ b/src/models/notification_model.py
@@ -130,10 +130,14 @@ def create_discord_notification_from_issue(issue: IssueModel, webhook_url: str) 
     priority = priority_map.get(issue.bug_analysis.severity, NotificationPriority.NORMAL)
     
     # Criar notificação Discord
+    description = issue.draft.description[:500] + "..." if len(issue.draft.description) > 500 else issue.draft.description
+    if issue.github_issue_url:
+        description += f"\n\n[🔗 Abrir Issue]({issue.github_issue_url})"
+
     discord_data = DiscordNotification(
         webhook_url=webhook_url,
         embed_title=f"🐛 Nova Issue Criada: {issue.draft.title}",
-        embed_description=issue.draft.description[:500] + "..." if len(issue.draft.description) > 500 else issue.draft.description
+        embed_description=description
     )
     
     # Definir cor baseada na prioridade
@@ -143,6 +147,7 @@ def create_discord_notification_from_issue(issue: IssueModel, webhook_url: str) 
     discord_data.add_field("Severidade", issue.bug_analysis.severity.value.title(), True)
     discord_data.add_field("Categoria", issue.bug_analysis.category.value.replace("_", " ").title(), True)
     discord_data.add_field("Prioridade", issue.draft.priority.value.title(), True)
+    discord_data.add_field("Impacto", issue.bug_analysis.impact.value.replace("_", " ").title(), True)
     
     if issue.github_issue_url:
         discord_data.add_field("GitHub", f"[Ver Issue]({issue.github_issue_url})", False)


### PR DESCRIPTION
## Summary
- extend `IssueDraft` with `resolution_steps`
- display a resolution plan in issue markdown
- parse and refine `resolution_steps` in `IssueManagerAgent`
- include resolution steps when generating critical issues
- improve `create_discord_notification_from_issue` layout
- update prompts with new instructions for resolution steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844dbc02e088329bc90c0e145c294ca